### PR TITLE
Fix page breaks and section headers

### DIFF
--- a/USFMToolsSharp.Renderers.Docx.Tests/DocxRendererTests.cs
+++ b/USFMToolsSharp.Renderers.Docx.Tests/DocxRendererTests.cs
@@ -1,9 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NPOI.XWPF.UserModel;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
 using USFMToolsSharp.Models.Markers;
 
 namespace USFMToolsSharp.Renderers.Docx.Tests
@@ -26,10 +22,21 @@ namespace USFMToolsSharp.Renderers.Docx.Tests
         public void TestHeaderRender()
         {
             Assert.AreEqual("Genesis",renderDoc("\\h Genesis").Paragraphs[0].Text);
+        }
+        
+        [TestMethod]
+        public void TestHeaderRenderTwoWords()
+        {
             Assert.AreEqual("1 John", renderDoc("\\h 1 John").Paragraphs[0].Text);
+        }
+        
+        [TestMethod]
+        public void TestHeaderRenderBlank()
+        {
             Assert.AreEqual("", renderDoc("\\h      ").Paragraphs[0].Text);
 
         }
+
         [TestMethod]
         public void TestChapterRender()
         {
@@ -38,6 +45,7 @@ namespace USFMToolsSharp.Renderers.Docx.Tests
             Assert.AreEqual("-1", renderDoc("\\c -1").Paragraphs[0].Text);
             Assert.AreEqual("0", renderDoc("\\c 0").Paragraphs[0].Text);
         }
+
         [TestMethod]
         public void TestVerseRender()
         {
@@ -45,31 +53,12 @@ namespace USFMToolsSharp.Renderers.Docx.Tests
             Assert.AreEqual("1This is a simple verse.2Another one.", renderDoc("\\c 1 \\v 1 This is a simple verse. \\v 2 Another one.").Paragraphs[1].ParagraphText);
             Assert.AreEqual("2Another one.", renderDoc("\\c 1 \\v 1 This is a simple verse. \\c 2 \\v 2 Another one.").Paragraphs[3].ParagraphText);
         }
+
         [TestMethod]
         public void TestFootnoteRender()
         {
             Assert.AreEqual("1Hello Friend", renderDoc("\\c 1 \\v 1 This is a simple verse. \\f + \\ft Hello Friend \\f*").Paragraphs[3].ParagraphText);
             Assert.AreEqual("1Hello Fried Friend", renderDoc("\\c 1 \\v 1 This is a simple verse. \\f + \\ft \\fqa Hello Fried Friend \\f*").Paragraphs[3].ParagraphText);
-        }
-
-        [TestMethod]
-        public void TestCraigMain()
-        {
-            parser = new USFMParser(new List<string> { "s5", "fqa*" });
-            string inputFilename = @"C:\Users\oliverc.WAOFFICE\Downloads\docx-testing\1JN_2JN_3JN.usfm";
-            string usfm = File.ReadAllText(inputFilename);
-            USFMDocument markerTree = parser.ParseFromString(usfm);
-            DocxConfig config = new DocxConfig();
-            //config.separateChapters = true;
-            render = new DocxRenderer(config);
-            XWPFDocument testDoc = render.Render(markerTree);
-
-            string outputFilename = @"C:\Users\oliverc.WAOFFICE\Downloads\docx-testing\out.docx";
-            using (FileStream fs = File.OpenWrite(outputFilename))
-            {
-                testDoc.Write(fs);
-            }
-
         }
 
         public XWPFDocument renderDoc(string usfm)

--- a/USFMToolsSharp.Renderers.Docx.Tests/DocxRendererTests.cs
+++ b/USFMToolsSharp.Renderers.Docx.Tests/DocxRendererTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NPOI.XWPF.UserModel;
+using NPOI.OpenXmlFormats.Wordprocessing;
 using USFMToolsSharp.Models.Markers;
 
 namespace USFMToolsSharp.Renderers.Docx.Tests
@@ -34,6 +35,33 @@ namespace USFMToolsSharp.Renderers.Docx.Tests
         public void TestHeaderRenderBlank()
         {
             Assert.AreEqual("", renderDoc("\\h      ").Paragraphs[0].Text);
+        }
+
+        [TestMethod]
+        public void TestHeadersCreateSections()
+        {
+            XWPFDocument doc = renderDoc("\\h 1 John \\c 1 \\v 1 Text \\h 2 John \\c 1 \\v 1 Text");
+            Assert.AreEqual(7, doc.Paragraphs.Count);
+
+            // Header
+            Assert.AreEqual("1 John", doc.Paragraphs[0].Text);
+            // Chapter
+            Assert.AreEqual("1", doc.Paragraphs[1].Text);
+            // Verse
+            Assert.AreEqual("1Text", doc.Paragraphs[2].Text);
+            // Line break
+            Assert.AreEqual("\n", doc.Paragraphs[3].Text);
+            // New book: Section break exists at end and has a header
+            Assert.IsNotNull(((CT_P)doc.Document.body.Items[3]).pPr.sectPr.headerReference);
+
+            // Header
+            Assert.AreEqual("2 John", doc.Paragraphs[4].Text);
+            // Chapter
+            Assert.AreEqual("1", doc.Paragraphs[5].Text);
+            // Verse
+            Assert.AreEqual("1Text", doc.Paragraphs[6].Text);
+            // Final book: Section break exists at end and has a header
+            Assert.IsNotNull(((CT_P)doc.Document.body.Items[8]).pPr.sectPr.headerReference);
 
         }
 

--- a/USFMToolsSharp.Renderers.Docx.Tests/DocxRendererTests.cs
+++ b/USFMToolsSharp.Renderers.Docx.Tests/DocxRendererTests.cs
@@ -59,6 +59,9 @@ namespace USFMToolsSharp.Renderers.Docx.Tests
             string inputFilename = @"C:\Users\oliverc.WAOFFICE\Downloads\docx-testing\1JN_2JN_3JN.usfm";
             string usfm = File.ReadAllText(inputFilename);
             USFMDocument markerTree = parser.ParseFromString(usfm);
+            DocxConfig config = new DocxConfig();
+            //config.separateChapters = true;
+            render = new DocxRenderer(config);
             XWPFDocument testDoc = render.Render(markerTree);
 
             string outputFilename = @"C:\Users\oliverc.WAOFFICE\Downloads\docx-testing\out.docx";

--- a/USFMToolsSharp.Renderers.Docx.Tests/DocxRendererTests.cs
+++ b/USFMToolsSharp.Renderers.Docx.Tests/DocxRendererTests.cs
@@ -70,6 +70,44 @@ namespace USFMToolsSharp.Renderers.Docx.Tests
         }
 
         [TestMethod]
+        public void TestHeadersCreateSectionsOneBook()
+        {
+            XWPFDocument doc = renderDoc("\\h 1 John \\c 1 \\v 1 Text");
+
+            // 3 paragraphs: H C V
+            Assert.AreEqual(3, doc.Paragraphs.Count);
+            // 4 body items: same as above plus one section header
+            Assert.AreEqual(4, doc.Document.body.Items.Count);
+
+            // Header
+            Assert.AreEqual("1 John", doc.Paragraphs[0].Text);
+            // Chapter
+            Assert.AreEqual("1", doc.Paragraphs[1].Text);
+            // Verse
+            Assert.AreEqual("1Text", doc.Paragraphs[2].Text);
+            // New book: Section break exists at end and has a header
+            Assert.IsNotNull(((CT_P)doc.Document.body.Items[3]).pPr.sectPr.headerReference);
+
+        }
+
+        [TestMethod]
+        public void TestHeadersCreateSectionsNoBooks()
+        {
+            XWPFDocument doc = renderDoc("\\c 1 \\v 1 Text");
+
+            // 2 paragraphs: C V
+            Assert.AreEqual(2, doc.Paragraphs.Count);
+            // 2 body items: same as above (no section headers)
+            Assert.AreEqual(2, doc.Document.body.Items.Count);
+
+            // Chapter
+            Assert.AreEqual("1", doc.Paragraphs[0].Text);
+            // Verse
+            Assert.AreEqual("1Text", doc.Paragraphs[1].Text);
+
+        }
+
+        [TestMethod]
         public void TestChapterRender()
         {
             Assert.AreEqual("5", renderDoc("\\c 5").Paragraphs[0].Text);

--- a/USFMToolsSharp.Renderers.Docx.Tests/DocxRendererTests.cs
+++ b/USFMToolsSharp.Renderers.Docx.Tests/DocxRendererTests.cs
@@ -41,7 +41,11 @@ namespace USFMToolsSharp.Renderers.Docx.Tests
         public void TestHeadersCreateSections()
         {
             XWPFDocument doc = renderDoc("\\h 1 John \\c 1 \\v 1 Text \\h 2 John \\c 1 \\v 1 Text");
+
+            // 7 paragraphs: H C V (pagebreak) H C V
             Assert.AreEqual(7, doc.Paragraphs.Count);
+            // 9 body items: same as above plus two section headers
+            Assert.AreEqual(9, doc.Document.body.Items.Count);
 
             // Header
             Assert.AreEqual("1 John", doc.Paragraphs[0].Text);

--- a/USFMToolsSharp.Renderers.Docx.Tests/DocxRendererTests.cs
+++ b/USFMToolsSharp.Renderers.Docx.Tests/DocxRendererTests.cs
@@ -2,6 +2,7 @@
 using NPOI.XWPF.UserModel;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using USFMToolsSharp.Models.Markers;
 
@@ -49,6 +50,23 @@ namespace USFMToolsSharp.Renderers.Docx.Tests
         {
             Assert.AreEqual("1Hello Friend", renderDoc("\\c 1 \\v 1 This is a simple verse. \\f + \\ft Hello Friend \\f*").Paragraphs[3].ParagraphText);
             Assert.AreEqual("1Hello Fried Friend", renderDoc("\\c 1 \\v 1 This is a simple verse. \\f + \\ft \\fqa Hello Fried Friend \\f*").Paragraphs[3].ParagraphText);
+        }
+
+        [TestMethod]
+        public void TestCraigMain()
+        {
+            parser = new USFMParser(new List<string> { "s5", "fqa*" });
+            string inputFilename = @"C:\Users\oliverc.WAOFFICE\Downloads\docx-testing\1JN_2JN_3JN.usfm";
+            string usfm = File.ReadAllText(inputFilename);
+            USFMDocument markerTree = parser.ParseFromString(usfm);
+            XWPFDocument testDoc = render.Render(markerTree);
+
+            string outputFilename = @"C:\Users\oliverc.WAOFFICE\Downloads\docx-testing\out.docx";
+            using (FileStream fs = File.OpenWrite(outputFilename))
+            {
+                testDoc.Write(fs);
+            }
+
         }
 
         public XWPFDocument renderDoc(string usfm)

--- a/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
+++ b/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
@@ -158,17 +158,6 @@ namespace USFMToolsSharp.Renderers.Docx
                     headerTitle.SetText(hMarker.HeaderText);
 
                     break;
-                //case MTMarker mTMarker:
-                    //if (configDocx.separateChapters) 
-                    //{
-                    //    newDoc.CreateParagraph().CreateRun().AddBreak(BreakType.PAGE);
-                    //}
-                    //foreach (Marker marker in input.Contents)
-                    //{
-                    //    RenderMarker(marker,markerStyle);
-                    //}
-                    //createBookHeaders(mTMarker.Title);
-                    //break;
                 case FMarker fMarker:
                     string footnoteId;
                     switch (fMarker.FootNoteCaller)

--- a/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
+++ b/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
@@ -122,22 +122,23 @@ namespace USFMToolsSharp.Renderers.Docx
                     }
                     break;
                 case HMarker hMarker:
+                    newDoc.CreateParagraph().CreateRun().AddBreak(BreakType.PAGE);
                     markerStyle.fontSize = 24;
                     XWPFParagraph newHeader = newDoc.CreateParagraph(markerStyle);
                     XWPFRun headerTitle = newHeader.CreateRun(markerStyle);
                     headerTitle.SetText(hMarker.HeaderText);
                     break;
-                case MTMarker mTMarker:
-                    foreach (Marker marker in input.Contents)
-                    {
-                        RenderMarker(marker,markerStyle);
-                    }
-                    if (!configDocx.separateChapters)   // No double page breaks before books
-                    {
-                        newDoc.CreateParagraph().CreateRun().AddBreak(BreakType.PAGE);
-                    }
-                    createBookHeaders(mTMarker.Title);
-                    break;
+                //case MTMarker mTMarker:
+                    //if (configDocx.separateChapters) 
+                    //{
+                    //    newDoc.CreateParagraph().CreateRun().AddBreak(BreakType.PAGE);
+                    //}
+                    //foreach (Marker marker in input.Contents)
+                    //{
+                    //    RenderMarker(marker,markerStyle);
+                    //}
+                    //createBookHeaders(mTMarker.Title);
+                    //break;
                 case FMarker fMarker:
                     string footnoteId;
                     switch (fMarker.FootNoteCaller)

--- a/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
+++ b/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
@@ -16,7 +16,7 @@ namespace USFMToolsSharp.Renderers.Docx
         public Dictionary<string, Marker> CrossRefMarkers;
         private DocxConfig configDocx;
         private XWPFDocument newDoc;
-        private int bookNameCount = 1;
+        private int pageHeaderCount = 1;
         private string previousBookHeader = null;
 
         public DocxRenderer()
@@ -46,12 +46,19 @@ namespace USFMToolsSharp.Renderers.Docx
                 }
 
             // Add section header for final book
-            // (section page headers are set at the final paragraph of the section)
             if (previousBookHeader != null)
             {
                 createBookHeaders(previousBookHeader);
             }
 
+            // Make final document section continuous so that it doesn't
+            // create an extra page at the end.  Final section is unique:
+            // it's a direct child of the document, not a child of the last
+            // paragraph.
+            CT_SectPr finalSection = new CT_SectPr();
+            finalSection.type = new CT_SectType();
+            finalSection.type.val = ST_SectionMark.continuous;
+            newDoc.Document.body.sectPr = finalSection;
 
             return newDoc;
 
@@ -139,10 +146,8 @@ namespace USFMToolsSharp.Renderers.Docx
                     {
                         // Create new section and page header
                         createBookHeaders(previousBookHeader);
-
                         // Print page break
                         newDoc.CreateParagraph().CreateRun().AddBreak(BreakType.PAGE);
-
                     }
                     previousBookHeader = hMarker.HeaderText;
 
@@ -381,8 +386,17 @@ namespace USFMToolsSharp.Renderers.Docx
 
         }
         
+        /// <summary>
+        /// Creates a new section with the given page header.  Must be
+        /// called *after* the final paragraph of the section.  In DOCX, a
+        /// section definition is a child of the final paragraph of the
+        /// section, except for the final paragraph of the document, which
+        /// is a direct child of the body.
+        /// </summary>
+        /// <param name="bookname"> The name of the book to display, usually from the \h marker </param>
         public void createBookHeaders(string bookname)
-        {
+        { 
+            // Create page heading content for book
             CT_Hdr header = new CT_Hdr();
             CT_P headerParagraph = header.AddNewP();
             CT_PPr ppr = headerParagraph.AddNewPPr();
@@ -390,17 +404,20 @@ namespace USFMToolsSharp.Renderers.Docx
             align.val = ST_Jc.left;
             headerParagraph.AddNewR().AddNewT().Value = bookname;
 
-            // newDoc.HeaderList doesn't update with header additions
-            XWPFHeader documentHeader = (XWPFHeader)newDoc.CreateRelationship(XWPFRelation.HEADER, XWPFFactory.GetInstance(), bookNameCount);
+            // Create page header
+            XWPFHeader documentHeader = (XWPFHeader)newDoc.CreateRelationship(XWPFRelation.HEADER, XWPFFactory.GetInstance(), pageHeaderCount);
             documentHeader.SetHeaderFooter(header);
-            CT_SectPr diffHeader = newDoc.Document.body.AddNewP().AddNewPPr().createSectPr();
-            diffHeader.type = new CT_SectType();
-            diffHeader.type.val = ST_SectionMark.continuous;
-            CT_HdrFtrRef headerRef = diffHeader.AddNewHeaderReference();
+
+            // Create new section and set its header
+            CT_SectPr newSection = newDoc.Document.body.AddNewP().AddNewPPr().createSectPr();
+            newSection.type = new CT_SectType();
+            newSection.type.val = ST_SectionMark.continuous;
+            CT_HdrFtrRef headerRef = newSection.AddNewHeaderReference();
             headerRef.type = ST_HdrFtr.@default;
             headerRef.id = documentHeader.GetPackageRelationship().Id;
 
-            bookNameCount++;
+            // Increment page header count so each one gets a unique ID
+            pageHeaderCount++;
         }
         public void getRenderedRows(Marker input, StyleConfig config,XWPFTable parentTable)
         {

--- a/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
+++ b/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
@@ -379,7 +379,7 @@ namespace USFMToolsSharp.Renderers.Docx
         /// Creates a new section with the given page header.  Must be
         /// called *after* the final paragraph of the section.  In DOCX, a
         /// section definition is a child of the final paragraph of the
-        /// section, except for the final paragraph of the document, which
+        /// section, except for the final section of the document, which
         /// is a direct child of the body.
         /// </summary>
         /// <param name="bookname"> The name of the book to display, usually from the \h marker </param>

--- a/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
+++ b/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
@@ -17,6 +17,7 @@ namespace USFMToolsSharp.Renderers.Docx
         private DocxConfig configDocx;
         private XWPFDocument newDoc;
         private int bookNameCount=1;
+        private bool firstBookHeader = true;
 
         public DocxRenderer()
         {
@@ -122,7 +123,16 @@ namespace USFMToolsSharp.Renderers.Docx
                     }
                     break;
                 case HMarker hMarker:
-                    newDoc.CreateParagraph().CreateRun().AddBreak(BreakType.PAGE);
+                    if (firstBookHeader)
+                    {
+                        // Don't page break before first book
+                        firstBookHeader = false;
+                    } 
+                    else
+                    {
+                        // Print page break before subsequent books
+                        newDoc.CreateParagraph().CreateRun().AddBreak(BreakType.PAGE);
+                    }
                     markerStyle.fontSize = 24;
                     XWPFParagraph newHeader = newDoc.CreateParagraph(markerStyle);
                     XWPFRun headerTitle = newHeader.CreateRun(markerStyle);


### PR DESCRIPTION
This change contains the following fixes:
- Page headers now print the name of the current book instead of the next book (or no book).
- Page headers are now based off the `\h` tag instead of the `\mt` tag.
- The renderer no longer prints a page break at the beginning of the document.
- The renderer no longer prints a page break at the end of the document.
- Split apart a test that needs setup and teardown for each assert