### PR TITLE
Fix chapter bugs

### DIFF
--- a/USFMToolsSharp.Renderers.Docx.Tests/DocxRendererTests.cs
+++ b/USFMToolsSharp.Renderers.Docx.Tests/DocxRendererTests.cs
@@ -51,7 +51,7 @@ namespace USFMToolsSharp.Renderers.Docx.Tests
             // Header
             Assert.AreEqual("1 John", doc.Paragraphs[0].Text);
             // Chapter
-            Assert.AreEqual("1", doc.Paragraphs[1].Text);
+            Assert.AreEqual("Chapter 1", doc.Paragraphs[1].Text);
             // Verse
             Assert.AreEqual("1 Text ", doc.Paragraphs[2].Text);
             // Line break
@@ -62,7 +62,7 @@ namespace USFMToolsSharp.Renderers.Docx.Tests
             // Header
             Assert.AreEqual("2 John", doc.Paragraphs[4].Text);
             // Chapter
-            Assert.AreEqual("1", doc.Paragraphs[5].Text);
+            Assert.AreEqual("Chapter 1", doc.Paragraphs[5].Text);
             // Verse
             Assert.AreEqual("1 Text", doc.Paragraphs[6].Text);
             // Final book: Section break exists at end and has a header
@@ -83,7 +83,7 @@ namespace USFMToolsSharp.Renderers.Docx.Tests
             // Header
             Assert.AreEqual("1 John", doc.Paragraphs[0].Text);
             // Chapter
-            Assert.AreEqual("1", doc.Paragraphs[1].Text);
+            Assert.AreEqual("Chapter 1", doc.Paragraphs[1].Text);
             // Verse
             Assert.AreEqual("1 Text", doc.Paragraphs[2].Text);
             // New book: Section break exists at end and has a header
@@ -102,7 +102,7 @@ namespace USFMToolsSharp.Renderers.Docx.Tests
             Assert.AreEqual(2, doc.Document.body.Items.Count);
 
             // Chapter
-            Assert.AreEqual("1", doc.Paragraphs[0].Text);
+            Assert.AreEqual("Chapter 1", doc.Paragraphs[0].Text);
             // Verse
             Assert.AreEqual("1 Text", doc.Paragraphs[1].Text);
 
@@ -111,10 +111,10 @@ namespace USFMToolsSharp.Renderers.Docx.Tests
         [TestMethod]
         public void TestChapterRender()
         {
-            Assert.AreEqual("5", renderDoc("\\c 5").Paragraphs[0].Text);
-            Assert.AreEqual("1", renderDoc("\\c 1").Paragraphs[0].Text);
-            Assert.AreEqual("-1", renderDoc("\\c -1").Paragraphs[0].Text);
-            Assert.AreEqual("0", renderDoc("\\c 0").Paragraphs[0].Text);
+            Assert.AreEqual("Chapter 5", renderDoc("\\c 5").Paragraphs[0].Text);
+            Assert.AreEqual("Chapter 1", renderDoc("\\c 1").Paragraphs[0].Text);
+            Assert.AreEqual("Chapter -1", renderDoc("\\c -1").Paragraphs[0].Text);
+            Assert.AreEqual("Chapter 0", renderDoc("\\c 0").Paragraphs[0].Text);
         }
 
         [TestMethod]
@@ -166,9 +166,9 @@ namespace USFMToolsSharp.Renderers.Docx.Tests
         [TestMethod]
         public void TestChapterLabelIndividual()
         {
-            string usfm = "\\c 1 \\cl Psalm \\v 1 First verse. \\c 2 \\v 1 First verse.";
+            string usfm = "\\c 1 \\cl Psalm One \\v 1 First verse. \\c 2 \\v 1 First verse.";
             XWPFDocument doc = renderDoc(usfm);
-            Assert.AreEqual("Psalm 1",doc.Paragraphs[0].Text);
+            Assert.AreEqual("Psalm One",doc.Paragraphs[0].Text);
             Assert.AreEqual("Chapter 2",doc.Paragraphs[2].Text);
         }
 

--- a/USFMToolsSharp.Renderers.Docx.Tests/DocxRendererTests.cs
+++ b/USFMToolsSharp.Renderers.Docx.Tests/DocxRendererTests.cs
@@ -146,6 +146,32 @@ namespace USFMToolsSharp.Renderers.Docx.Tests
             Assert.AreEqual("1Hello Fried Friend ", renderDoc("\\c 1 \\v 1 This is a simple verse. \\f + \\ft \\fqa Hello Fried Friend \\f*").Paragraphs[3].ParagraphText);
         }
 
+        [TestMethod]
+        public void TestChapterLabelNone()
+        {
+            string usfm = "\\c 1 \\v 1 First verse. \\v 2 Second verse.";
+            XWPFDocument doc = renderDoc(usfm);
+            Assert.AreEqual("Chapter 1",doc.Paragraphs[0].Text);
+        }
+
+        [TestMethod]
+        public void TestChapterLabelDoc()
+        {
+            string usfm = "\\cl Psalm \\c 1 \\v 1 First verse. \\c 2 \\v 1 First verse.";
+            XWPFDocument doc = renderDoc(usfm);
+            Assert.AreEqual("Psalm 1",doc.Paragraphs[0].Text);
+            Assert.AreEqual("Psalm 2",doc.Paragraphs[2].Text);
+        }
+
+        [TestMethod]
+        public void TestChapterLabelIndividual()
+        {
+            string usfm = "\\c 1 \\cl Psalm \\v 1 First verse. \\c 2 \\v 1 First verse.";
+            XWPFDocument doc = renderDoc(usfm);
+            Assert.AreEqual("Psalm 1",doc.Paragraphs[0].Text);
+            Assert.AreEqual("Chapter 2",doc.Paragraphs[2].Text);
+        }
+
         public XWPFDocument renderDoc(string usfm)
         {
             USFMDocument markerTree = parser.ParseFromString(usfm);

--- a/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
+++ b/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
@@ -18,6 +18,7 @@ namespace USFMToolsSharp.Renderers.Docx
         private XWPFDocument newDoc;
         private int pageHeaderCount = 1;
         private string previousBookHeader = null;
+        private bool firstChapterOfBook = true;
 
         public DocxRenderer()
         {
@@ -73,13 +74,26 @@ namespace USFMToolsSharp.Renderers.Docx
 
                     newParagraph.Alignment = configDocx.textAlign;
                     newParagraph.SpacingBetween = configDocx.lineSpacing;
-                        
+
                     foreach (Marker marker in input.Contents)
                     {
                         RenderMarker(marker, markerStyle, newParagraph);
                     }
                     break;
                 case CMarker cMarker:
+
+                    if (firstChapterOfBook)
+                    {
+                        firstChapterOfBook = false;
+                    }
+                    else
+                    {
+                        if (configDocx.separateChapters)
+                        {
+                            newDoc.CreateParagraph().CreateRun().AddBreak(BreakType.PAGE);
+                        }
+                    }
+
                     XWPFParagraph newChapter = newDoc.CreateParagraph(markerStyle);
                     XWPFRun chapterMarker = newChapter.CreateRun(markerStyle);
                     chapterMarker.SetText(cMarker.Number.ToString());
@@ -93,10 +107,6 @@ namespace USFMToolsSharp.Renderers.Docx
 
                     RenderFootnotes(markerStyle);
                     RenderCrossReferences(markerStyle);
-                    if (configDocx.separateChapters)
-                    {
-                        newDoc.CreateParagraph().CreateRun().AddBreak(BreakType.PAGE);
-                    }
 
                     break;
                 case VMarker vMarker:
@@ -273,10 +283,12 @@ namespace USFMToolsSharp.Renderers.Docx
                     XWPFRun newLineBreak = parentParagraph.CreateRun();
                     newLineBreak.AddBreak(BreakType.TEXTWRAPPING);
                     break;
+                case IDMarker _:
+                    firstChapterOfBook = true;
+                    break;
                 case XEndMarker _:
                 case FEndMarker _:
                 case IDEMarker _:
-                case IDMarker _:
                 case VPMarker _:
                 case VPEndMarker _:
                     break;

--- a/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
+++ b/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
@@ -94,12 +94,14 @@ namespace USFMToolsSharp.Renderers.Docx
 
                     if (beforeFirstChapter)
                     {
+                        // We found the first chapter, so set the flag to false.
                         beforeFirstChapter = false;
                     }
                     else
                     {
                         if (configDocx.separateChapters)
                         {
+                            // Add page break between chapters.
                             newDoc.CreateParagraph().CreateRun().AddBreak(BreakType.PAGE);
                         }
                     }

--- a/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
+++ b/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
@@ -18,7 +18,9 @@ namespace USFMToolsSharp.Renderers.Docx
         private XWPFDocument newDoc;
         private int pageHeaderCount = 1;
         private string previousBookHeader = null;
-        private bool firstChapterOfBook = true;
+        private const string chapterLabelDefault = "Chapter";
+        private string chapterLabel = chapterLabelDefault;
+        private bool beforeFirstChapter = true;
 
         public DocxRenderer()
         {
@@ -80,11 +82,19 @@ namespace USFMToolsSharp.Renderers.Docx
                         RenderMarker(marker, markerStyle, newParagraph);
                     }
                     break;
+                case CLMarker clMarker:
+                    if (beforeFirstChapter)
+                    {
+                        // A CL before the first chapter means that we should use
+                        // this string instead of the word "Chapter".
+                        chapterLabel = clMarker.Label;
+                    }
+                    break;
                 case CMarker cMarker:
 
-                    if (firstChapterOfBook)
+                    if (beforeFirstChapter)
                     {
-                        firstChapterOfBook = false;
+                        beforeFirstChapter = false;
                     }
                     else
                     {
@@ -105,7 +115,7 @@ namespace USFMToolsSharp.Renderers.Docx
                     else
                     {
                         // Use the default chapter text for this section, e.g. "Chapter 1"
-                        chapterMarker.SetText("Chapter " + simpleNumber);
+                        chapterMarker.SetText(chapterLabel + " " + simpleNumber);
                     }
                     chapterMarker.FontSize = 20;
 
@@ -294,7 +304,9 @@ namespace USFMToolsSharp.Renderers.Docx
                     newLineBreak.AddBreak(BreakType.TEXTWRAPPING);
                     break;
                 case IDMarker _:
-                    firstChapterOfBook = true;
+                    // This is the start of a new book.
+                    beforeFirstChapter = true;
+                    chapterLabel = chapterLabelDefault;
                     break;
                 case XEndMarker _:
                 case FEndMarker _:

--- a/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
+++ b/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
@@ -96,7 +96,17 @@ namespace USFMToolsSharp.Renderers.Docx
 
                     XWPFParagraph newChapter = newDoc.CreateParagraph(markerStyle);
                     XWPFRun chapterMarker = newChapter.CreateRun(markerStyle);
-                    chapterMarker.SetText(cMarker.Number.ToString());
+                    string simpleNumber = cMarker.Number.ToString();
+                    if (cMarker.CustomChapterLabel != simpleNumber)
+                    {
+                        // Use the custom label for this section, e.g. "Psalm One" instead of "Chapter 1"
+                        chapterMarker.SetText(cMarker.CustomChapterLabel);
+                    }
+                    else
+                    {
+                        // Use the default chapter text for this section, e.g. "Chapter 1"
+                        chapterMarker.SetText("Chapter " + simpleNumber);
+                    }
                     chapterMarker.FontSize = 20;
 
                     XWPFParagraph chapterVerses = newDoc.CreateParagraph(markerStyle);


### PR DESCRIPTION
This PR makes the following changes:
- The word "Chapter" is now prepended to chapter numbers.
- If the `\cl` marker is present at the top of the document, the text is used instead of "Chapter".
- If the `\cl` marker is present after a chapter marker, that label is used instead of "Chapter x"