### PR TITLE
Footnotes and Chapters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+*.swp
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/USFMToolsSharp.Renderers.Docx.Tests/DocxRendererTests.cs
+++ b/USFMToolsSharp.Renderers.Docx.Tests/DocxRendererTests.cs
@@ -143,7 +143,7 @@ namespace USFMToolsSharp.Renderers.Docx.Tests
         public void TestSpaceBetweenVersesInParagraph()
         {
             XWPFDocument doc = renderDoc("\\c 1 \\p \\v 1 First Verse. \\v 2 Second verse.");
-            Assert.AreEqual("1 First Verse. 2 Second verse. ", doc.Paragraphs[2].ParagraphText);
+            Assert.AreEqual("1 First Verse. 2 Second verse. ", doc.Paragraphs[1].ParagraphText);
         }
 
         [TestMethod]

--- a/USFMToolsSharp.Renderers.Docx.Tests/DocxRendererTests.cs
+++ b/USFMToolsSharp.Renderers.Docx.Tests/DocxRendererTests.cs
@@ -51,7 +51,7 @@ namespace USFMToolsSharp.Renderers.Docx.Tests
             // Header
             Assert.AreEqual("1 John", doc.Paragraphs[0].Text);
             // Chapter
-            Assert.AreEqual("1", doc.Paragraphs[1].Text);
+            Assert.AreEqual("Chapter 1", doc.Paragraphs[1].Text);
             // Verse
             Assert.AreEqual("1 Text ", doc.Paragraphs[2].Text);
             // Line break
@@ -62,7 +62,7 @@ namespace USFMToolsSharp.Renderers.Docx.Tests
             // Header
             Assert.AreEqual("2 John", doc.Paragraphs[4].Text);
             // Chapter
-            Assert.AreEqual("1", doc.Paragraphs[5].Text);
+            Assert.AreEqual("Chapter 1", doc.Paragraphs[5].Text);
             // Verse
             Assert.AreEqual("1 Text", doc.Paragraphs[6].Text);
             // Final book: Section break exists at end and has a header
@@ -83,7 +83,7 @@ namespace USFMToolsSharp.Renderers.Docx.Tests
             // Header
             Assert.AreEqual("1 John", doc.Paragraphs[0].Text);
             // Chapter
-            Assert.AreEqual("1", doc.Paragraphs[1].Text);
+            Assert.AreEqual("Chapter 1", doc.Paragraphs[1].Text);
             // Verse
             Assert.AreEqual("1 Text", doc.Paragraphs[2].Text);
             // New book: Section break exists at end and has a header
@@ -102,7 +102,7 @@ namespace USFMToolsSharp.Renderers.Docx.Tests
             Assert.AreEqual(2, doc.Document.body.Items.Count);
 
             // Chapter
-            Assert.AreEqual("1", doc.Paragraphs[0].Text);
+            Assert.AreEqual("Chapter 1", doc.Paragraphs[0].Text);
             // Verse
             Assert.AreEqual("1 Text", doc.Paragraphs[1].Text);
 
@@ -111,10 +111,10 @@ namespace USFMToolsSharp.Renderers.Docx.Tests
         [TestMethod]
         public void TestChapterRender()
         {
-            Assert.AreEqual("5", renderDoc("\\c 5").Paragraphs[0].Text);
-            Assert.AreEqual("1", renderDoc("\\c 1").Paragraphs[0].Text);
-            Assert.AreEqual("-1", renderDoc("\\c -1").Paragraphs[0].Text);
-            Assert.AreEqual("0", renderDoc("\\c 0").Paragraphs[0].Text);
+            Assert.AreEqual("Chapter 5", renderDoc("\\c 5").Paragraphs[0].Text);
+            Assert.AreEqual("Chapter 1", renderDoc("\\c 1").Paragraphs[0].Text);
+            Assert.AreEqual("Chapter -1", renderDoc("\\c -1").Paragraphs[0].Text);
+            Assert.AreEqual("Chapter 0", renderDoc("\\c 0").Paragraphs[0].Text);
         }
 
         [TestMethod]
@@ -166,9 +166,9 @@ namespace USFMToolsSharp.Renderers.Docx.Tests
         [TestMethod]
         public void TestChapterLabelIndividual()
         {
-            string usfm = "\\c 1 \\cl Psalm \\v 1 First verse. \\c 2 \\v 1 First verse.";
+            string usfm = "\\c 1 \\cl Psalm One \\v 1 First verse. \\c 2 \\v 1 First verse.";
             XWPFDocument doc = renderDoc(usfm);
-            Assert.AreEqual("Psalm 1",doc.Paragraphs[0].Text);
+            Assert.AreEqual("Psalm One",doc.Paragraphs[0].Text);
             Assert.AreEqual("Chapter 2",doc.Paragraphs[2].Text);
         }
 

--- a/USFMToolsSharp.Renderers.Docx.Tests/DocxRendererTests.cs
+++ b/USFMToolsSharp.Renderers.Docx.Tests/DocxRendererTests.cs
@@ -64,7 +64,7 @@ namespace USFMToolsSharp.Renderers.Docx.Tests
             // Chapter
             Assert.AreEqual("Chapter 1", doc.Paragraphs[5].Text);
             // Verse
-            Assert.AreEqual("1 Text", doc.Paragraphs[6].Text);
+            Assert.AreEqual("1 Text ", doc.Paragraphs[6].Text);
             // Final book: Section break exists at end and has a header
             Assert.IsNotNull(((CT_P)doc.Document.body.Items[8]).pPr.sectPr.headerReference);
 
@@ -85,7 +85,7 @@ namespace USFMToolsSharp.Renderers.Docx.Tests
             // Chapter
             Assert.AreEqual("Chapter 1", doc.Paragraphs[1].Text);
             // Verse
-            Assert.AreEqual("1 Text", doc.Paragraphs[2].Text);
+            Assert.AreEqual("1 Text ", doc.Paragraphs[2].Text);
             // New book: Section break exists at end and has a header
             Assert.IsNotNull(((CT_P)doc.Document.body.Items[3]).pPr.sectPr.headerReference);
 
@@ -104,7 +104,7 @@ namespace USFMToolsSharp.Renderers.Docx.Tests
             // Chapter
             Assert.AreEqual("Chapter 1", doc.Paragraphs[0].Text);
             // Verse
-            Assert.AreEqual("1 Text", doc.Paragraphs[1].Text);
+            Assert.AreEqual("1 Text ", doc.Paragraphs[1].Text);
 
         }
 
@@ -120,23 +120,30 @@ namespace USFMToolsSharp.Renderers.Docx.Tests
         [TestMethod]
         public void TestVerseRender()
         {
-            Assert.AreEqual("1 This is a simple verse.", renderDoc("\\c 1 \\v 1 This is a simple verse.").Paragraphs[1].ParagraphText);
-            Assert.AreEqual("1 This is a simple verse. 2 Another one.", renderDoc("\\c 1 \\v 1 This is a simple verse. \\v 2 Another one.").Paragraphs[1].ParagraphText);
-            Assert.AreEqual("2 Another one.", renderDoc("\\c 1 \\v 1 This is a simple verse. \\c 2 \\v 2 Another one.").Paragraphs[3].ParagraphText);
+            Assert.AreEqual("1 This is a simple verse. ", renderDoc("\\c 1 \\v 1 This is a simple verse.").Paragraphs[1].ParagraphText);
+            Assert.AreEqual("1 This is a simple verse. 2 Another one. ", renderDoc("\\c 1 \\v 1 This is a simple verse. \\v 2 Another one.").Paragraphs[1].ParagraphText);
+            Assert.AreEqual("2 Another one. ", renderDoc("\\c 1 \\v 1 This is a simple verse. \\c 2 \\v 2 Another one.").Paragraphs[3].ParagraphText);
         }
 
         [TestMethod]
         public void TestSpaceBetweenVerses()
         {
             XWPFDocument doc = renderDoc("\\c 1 \\v 1 First Verse. \\v 2 Second verse.");
-            Assert.AreEqual("1 First Verse. 2 Second verse.", doc.Paragraphs[1].ParagraphText);
+            Assert.AreEqual("1 First Verse. 2 Second verse. ", doc.Paragraphs[1].ParagraphText);
+        }
+
+        [TestMethod]
+        public void TestSpaceBetweenVersesOnSeparateInputLines()
+        {
+            XWPFDocument doc = renderDoc("\\c 1 \\v 1 First Verse.\n\\v 2 Second verse.");
+            Assert.AreEqual("1 First Verse. 2 Second verse. ", doc.Paragraphs[1].ParagraphText);
         }
 
         [TestMethod]
         public void TestSpaceBetweenVersesInParagraph()
         {
             XWPFDocument doc = renderDoc("\\c 1 \\p \\v 1 First Verse. \\v 2 Second verse.");
-            Assert.AreEqual("1 First Verse. 2 Second verse.", doc.Paragraphs[2].ParagraphText);
+            Assert.AreEqual("1 First Verse. 2 Second verse. ", doc.Paragraphs[2].ParagraphText);
         }
 
         [TestMethod]
@@ -148,7 +155,7 @@ namespace USFMToolsSharp.Renderers.Docx.Tests
             // Verse 1
             Assert.AreEqual("1", doc.Paragraphs[1].Runs[0].Text);
             // Footnote Reference 1
-            CT_FtnEdnRef footnoteRef = (CT_FtnEdnRef)doc.Paragraphs[1].Runs[4].GetCTR().Items[1];
+            CT_FtnEdnRef footnoteRef = (CT_FtnEdnRef)doc.Paragraphs[1].Runs[3].GetCTR().Items[1];
             Assert.AreEqual("1", footnoteRef.id);
             // Footnote Content 1
             XWPFFootnote footnote = doc.GetFootnotes()[0];

--- a/USFMToolsSharp.Renderers.Docx.Tests/DocxRendererTests.cs
+++ b/USFMToolsSharp.Renderers.Docx.Tests/DocxRendererTests.cs
@@ -146,6 +146,32 @@ namespace USFMToolsSharp.Renderers.Docx.Tests
             Assert.AreEqual("1Hello Fried Friend ", renderDoc("\\c 1 \\v 1 This is a simple verse. \\f + \\ft \\fqa Hello Fried Friend \\f*").Paragraphs[3].ParagraphText);
         }
 
+        [TestMethod]
+        public void TestChapterLabelNone()
+        {
+            string usfm = "\\c 1 \\v 1 First verse. \\v 2 Second verse.";
+            XWPFDocument doc = renderDoc(usfm);
+            Assert.AreEqual("Chapter 1",doc.Paragraphs[0].Text);
+        }
+
+        [TestMethod]
+        public void TestChapterLabelDoc()
+        {
+            string usfm = "\\cl Psalm \\c 1 \\v 1 First verse. \\c 2 \\v 1 First verse.";
+            XWPFDocument doc = renderDoc(usfm);
+            Assert.AreEqual("Psalm 1",doc.Paragraphs[0].Text);
+            Assert.AreEqual("Psalm 2",doc.Paragraphs[2].Text);
+        }
+
+        [TestMethod]
+        public void TestChapterLabelIndividual()
+        {
+            string usfm = "\\c 1 \\cl Psalm \\v 1 First verse. \\c 2 \\v 1 First verse.";
+            XWPFDocument doc = renderDoc(usfm);
+            Assert.AreEqual("Psalm 1",doc.Paragraphs[0].Text);
+            Assert.AreEqual("Chapter 2",doc.Paragraphs[2].Text);
+        }
+
         public XWPFDocument renderDoc(string usfm)
         {
             USFMDocument markerTree = parser.ParseFromString(usfm);

--- a/USFMToolsSharp.Renderers.Docx.Tests/DocxRendererTests.cs
+++ b/USFMToolsSharp.Renderers.Docx.Tests/DocxRendererTests.cs
@@ -142,8 +142,17 @@ namespace USFMToolsSharp.Renderers.Docx.Tests
         [TestMethod]
         public void TestFootnoteRender()
         {
-            Assert.AreEqual("1Hello Friend ", renderDoc("\\c 1 \\v 1 This is a simple verse. \\f + \\ft Hello Friend \\f*").Paragraphs[3].ParagraphText);
-            Assert.AreEqual("1Hello Fried Friend ", renderDoc("\\c 1 \\v 1 This is a simple verse. \\f + \\ft \\fqa Hello Fried Friend \\f*").Paragraphs[3].ParagraphText);
+            XWPFDocument doc = renderDoc("\\c 1 \\v 1 This is a verse. \\f + \\ft This is a footnote. \\f*");
+            // Chapter 1
+            Assert.AreEqual("Chapter 1", doc.Paragraphs[0].ParagraphText);
+            // Verse 1
+            Assert.AreEqual("1", doc.Paragraphs[1].Runs[1].Text);
+            // Footnote Reference 1
+            CT_FtnEdnRef footnoteRef = (CT_FtnEdnRef)doc.Paragraphs[1].Runs[5].GetCTR().Items[1];
+            Assert.AreEqual("1", footnoteRef.id);
+            // Footnote Content 1
+            XWPFFootnote footnote = doc.GetFootnotes()[0];
+            Assert.AreEqual("F1 This is a footnote. ", footnote.Paragraphs[0].ParagraphText);
         }
 
         [TestMethod]

--- a/USFMToolsSharp.Renderers.Docx.Tests/DocxRendererTests.cs
+++ b/USFMToolsSharp.Renderers.Docx.Tests/DocxRendererTests.cs
@@ -146,9 +146,9 @@ namespace USFMToolsSharp.Renderers.Docx.Tests
             // Chapter 1
             Assert.AreEqual("Chapter 1", doc.Paragraphs[0].ParagraphText);
             // Verse 1
-            Assert.AreEqual("1", doc.Paragraphs[1].Runs[1].Text);
+            Assert.AreEqual("1", doc.Paragraphs[1].Runs[0].Text);
             // Footnote Reference 1
-            CT_FtnEdnRef footnoteRef = (CT_FtnEdnRef)doc.Paragraphs[1].Runs[5].GetCTR().Items[1];
+            CT_FtnEdnRef footnoteRef = (CT_FtnEdnRef)doc.Paragraphs[1].Runs[4].GetCTR().Items[1];
             Assert.AreEqual("1", footnoteRef.id);
             // Footnote Content 1
             XWPFFootnote footnote = doc.GetFootnotes()[0];

--- a/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
+++ b/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
@@ -18,6 +18,7 @@ namespace USFMToolsSharp.Renderers.Docx
         private XWPFDocument newDoc;
         private int pageHeaderCount = 1;
         private string previousBookHeader = null;
+        private bool firstChapterOfBook = true;
 
         public DocxRenderer()
         {
@@ -73,13 +74,26 @@ namespace USFMToolsSharp.Renderers.Docx
 
                     newParagraph.Alignment = configDocx.textAlign;
                     newParagraph.SpacingBetween = configDocx.lineSpacing;
-                        
+
                     foreach (Marker marker in input.Contents)
                     {
                         RenderMarker(marker, markerStyle, newParagraph);
                     }
                     break;
                 case CMarker cMarker:
+
+                    if (firstChapterOfBook)
+                    {
+                        firstChapterOfBook = false;
+                    }
+                    else
+                    {
+                        if (configDocx.separateChapters)
+                        {
+                            newDoc.CreateParagraph().CreateRun().AddBreak(BreakType.PAGE);
+                        }
+                    }
+
                     XWPFParagraph newChapter = newDoc.CreateParagraph(markerStyle);
                     XWPFRun chapterMarker = newChapter.CreateRun(markerStyle);
                     chapterMarker.SetText(cMarker.Number.ToString());
@@ -93,10 +107,6 @@ namespace USFMToolsSharp.Renderers.Docx
 
                     RenderFootnotes(markerStyle);
                     RenderCrossReferences(markerStyle);
-                    if (configDocx.separateChapters)
-                    {
-                        newDoc.CreateParagraph().CreateRun().AddBreak(BreakType.PAGE);
-                    }
 
                     break;
                 case VMarker vMarker:
@@ -273,10 +283,12 @@ namespace USFMToolsSharp.Renderers.Docx
                     XWPFRun newLineBreak = parentParagraph.CreateRun();
                     newLineBreak.AddBreak(BreakType.TEXTWRAPPING);
                     break;
+                case IDMarker _:
+                    firstChapterOfBook = true;
+                    break;
                 case XEndMarker _:
                 case FEndMarker _:
                 case IDEMarker _:
-                case IDMarker _:
                 case VPMarker _:
                 case VPEndMarker _:
                     break;

--- a/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
+++ b/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
@@ -212,11 +212,16 @@ namespace USFMToolsSharp.Renderers.Docx
                             footnoteId = fMarker.FootNoteCaller;
                             break;
                     }
+
                     CT_FtnEdn footnote = new CT_FtnEdn();
                     footnote.id = footnoteId;
                     footnote.type = ST_FtnEdn.normal;
                     CT_P footnoteParagraph = footnote.AddNewP();
-                    footnoteParagraph.AddNewR().AddNewT().Value = footnoteId + " Placeholder Text";
+                    XWPFParagraph xFootnoteParagraph = new XWPFParagraph(footnoteParagraph, parentParagraph.Body);
+                    foreach(Marker marker in fMarker.Contents)
+                    {
+                        RenderMarker(marker, markerStyle, xFootnoteParagraph);
+                    }
                     parentParagraph.Document.AddFootnote(footnote);
 
                     XWPFRun footnoteReferenceRun = parentParagraph.CreateRun();

--- a/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
+++ b/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
@@ -140,6 +140,10 @@ namespace USFMToolsSharp.Renderers.Docx
                         XWPFRun newLine = parentParagraph.CreateRun();
                         newLine.AddBreak(BreakType.TEXTWRAPPING);
                     }
+                    else 
+                    { 
+                        AppendSpace(parentParagraph);
+                    }
 
                     XWPFRun verseMarker = parentParagraph.CreateRun(markerStyle);
                     verseMarker.SetText(vMarker.VerseCharacter);
@@ -212,7 +216,7 @@ namespace USFMToolsSharp.Renderers.Docx
                     footnote.id = footnoteId;
                     footnote.type = ST_FtnEdn.normal;
                     CT_P footnoteParagraph = footnote.AddNewP();
-                    footnoteParagraph.AddNewR().AddNewT().Value = "Placeholder Text";
+                    footnoteParagraph.AddNewR().AddNewT().Value = footnoteId + " Placeholder Text";
                     parentParagraph.Document.AddFootnote(footnote);
 
                     XWPFRun footnoteReferenceRun = parentParagraph.CreateRun();
@@ -323,6 +327,7 @@ namespace USFMToolsSharp.Renderers.Docx
                     // This is the start of a new book.
                     beforeFirstChapter = true;
                     chapterLabel = chapterLabelDefault;
+                    nextFootnoteNum = 1;
                     break;
                 case XEndMarker _:
                 case FEndMarker _:

--- a/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
+++ b/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
@@ -12,7 +12,6 @@ namespace USFMToolsSharp.Renderers.Docx
     public class DocxRenderer
     {
         public List<string> UnrenderableMarkers;
-        //public Dictionary<string,Marker> FootnoteMarkers;
         public Dictionary<string, Marker> CrossRefMarkers;
         private DocxConfig configDocx;
         private XWPFDocument newDoc;
@@ -35,7 +34,6 @@ namespace USFMToolsSharp.Renderers.Docx
         public XWPFDocument Render(USFMDocument input)
         {
             UnrenderableMarkers = new List<string>();
-            //FootnoteMarkers = new Dictionary<string, Marker>();
             CrossRefMarkers = new Dictionary<string, Marker>();
             newDoc = new XWPFDocument();
             newDoc.CreateFootnotes();
@@ -129,7 +127,6 @@ namespace USFMToolsSharp.Renderers.Docx
                         RenderMarker(marker, markerStyle ,chapterVerses);
                     }
 
-                    //RenderFootnotes(markerStyle);
                     RenderCrossReferences(markerStyle);
 
                     break;
@@ -142,7 +139,7 @@ namespace USFMToolsSharp.Renderers.Docx
                     }
                     else 
                     { 
-                        AppendSpace(parentParagraph);
+                        //AppendSpace(parentParagraph);
                     }
 
                     XWPFRun verseMarker = parentParagraph.CreateRun(markerStyle);
@@ -237,9 +234,6 @@ namespace USFMToolsSharp.Renderers.Docx
                     footnoteReferenceRun.SetUnderline(UnderlinePatterns.Single);
                     footnoteReferenceRun.AppendText("F");
                     footnoteReferenceRun.GetCTR().Items.Add(footnoteReference);
-
-                    //FootnoteMarkers[footnoteId] = fMarker;
-
                     break;
                 case FPMarker fPMarker:
                     foreach (Marker marker in input.Contents)
@@ -364,31 +358,6 @@ namespace USFMToolsSharp.Renderers.Docx
             text.Value = " ";
             text.space = "preserve";
         }
-
-        //private void RenderFootnotes(StyleConfig styles)
-        //{
-        //    if (FootnoteMarkers.Count > 0)
-        //    {
-        //        XWPFParagraph renderFootnoteStart = newDoc.CreateParagraph();
-        //        renderFootnoteStart.BorderTop = Borders.Single;
-
-        //        StyleConfig markerStyle = (StyleConfig)styles.Clone();
-        //        markerStyle.fontSize = 12;
-
-        //        foreach (KeyValuePair<string,Marker> footnoteKVP in FootnoteMarkers)
-        //        {
-        //            XWPFParagraph renderFootnote = newDoc.CreateParagraph(markerStyle);
-        //            XWPFRun footnoteMarker = renderFootnote.CreateRun(markerStyle);
-        //            footnoteMarker.SetText(footnoteKVP.Key);
-        //            footnoteMarker.Subscript = VerticalAlign.SUPERSCRIPT;
-        //            foreach(Marker input in footnoteKVP.Value.Contents)
-        //            {
-        //                RenderMarker(input, markerStyle, renderFootnote);
-        //            }
-        //        }
-        //        FootnoteMarkers.Clear();
-        //    }
-        //}
 
         private void RenderCrossReferences(StyleConfig config)
         {

--- a/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
+++ b/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
@@ -210,19 +210,8 @@ namespace USFMToolsSharp.Renderers.Docx
                     break;
                 case FMarker fMarker:
                     string footnoteId;
-                    switch (fMarker.FootNoteCaller)
-                    {
-                        case "-":
-                            footnoteId = "";
-                            break;
-                        case "+":
-                            footnoteId = nextFootnoteNum.ToString();
-                            nextFootnoteNum++;
-                            break;
-                        default:
-                            footnoteId = fMarker.FootNoteCaller;
-                            break;
-                    }
+                    footnoteId = nextFootnoteNum.ToString();
+                    nextFootnoteNum++;
 
                     CT_FtnEdn footnote = new CT_FtnEdn();
                     footnote.id = footnoteId;
@@ -345,7 +334,6 @@ namespace USFMToolsSharp.Renderers.Docx
                     // This is the start of a new book.
                     beforeFirstChapter = true;
                     chapterLabel = chapterLabelDefault;
-                    nextFootnoteNum = 1;
                     break;
                 case XEndMarker _:
                 case FEndMarker _:

--- a/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
+++ b/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
@@ -216,11 +216,14 @@ namespace USFMToolsSharp.Renderers.Docx
                     CT_FtnEdn footnote = new CT_FtnEdn();
                     footnote.id = footnoteId;
                     footnote.type = ST_FtnEdn.normal;
+                    StyleConfig footnoteMarkerStyle = (StyleConfig)styles.Clone();
+                    footnoteMarkerStyle.fontSize = 12;
                     CT_P footnoteParagraph = footnote.AddNewP();
                     XWPFParagraph xFootnoteParagraph = new XWPFParagraph(footnoteParagraph, parentParagraph.Body);
+                    footnoteParagraph.AddNewR().AddNewT().Value = "F" + footnoteId.ToString() + " ";
                     foreach(Marker marker in fMarker.Contents)
                     {
-                        RenderMarker(marker, markerStyle, xFootnoteParagraph);
+                        RenderMarker(marker, footnoteMarkerStyle, xFootnoteParagraph);
                     }
                     parentParagraph.Document.AddFootnote(footnote);
 
@@ -231,6 +234,8 @@ namespace USFMToolsSharp.Renderers.Docx
                     CT_FtnEdnRef footnoteReference = new CT_FtnEdnRef();
                     footnoteReference.id = footnoteId;
                     footnoteReference.isEndnote = false;
+                    footnoteReferenceRun.SetUnderline(UnderlinePatterns.Single);
+                    footnoteReferenceRun.AppendText("F");
                     footnoteReferenceRun.GetCTR().Items.Add(footnoteReference);
 
                     //FootnoteMarkers[footnoteId] = fMarker;

--- a/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
+++ b/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
@@ -94,12 +94,14 @@ namespace USFMToolsSharp.Renderers.Docx
 
                     if (beforeFirstChapter)
                     {
+                        // We found the first chapter, so set the flag to false.
                         beforeFirstChapter = false;
                     }
                     else
                     {
                         if (configDocx.separateChapters)
                         {
+                            // Add page break between chapters.
                             newDoc.CreateParagraph().CreateRun().AddBreak(BreakType.PAGE);
                         }
                     }

--- a/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
+++ b/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
@@ -18,7 +18,9 @@ namespace USFMToolsSharp.Renderers.Docx
         private XWPFDocument newDoc;
         private int pageHeaderCount = 1;
         private string previousBookHeader = null;
-        private bool firstChapterOfBook = true;
+        private const string chapterLabelDefault = "Chapter";
+        private string chapterLabel = chapterLabelDefault;
+        private bool beforeFirstChapter = true;
 
         public DocxRenderer()
         {
@@ -80,11 +82,19 @@ namespace USFMToolsSharp.Renderers.Docx
                         RenderMarker(marker, markerStyle, newParagraph);
                     }
                     break;
+                case CLMarker clMarker:
+                    if (beforeFirstChapter)
+                    {
+                        // A CL before the first chapter means that we should use
+                        // this string instead of the word "Chapter".
+                        chapterLabel = clMarker.Label;
+                    }
+                    break;
                 case CMarker cMarker:
 
-                    if (firstChapterOfBook)
+                    if (beforeFirstChapter)
                     {
-                        firstChapterOfBook = false;
+                        beforeFirstChapter = false;
                     }
                     else
                     {
@@ -105,7 +115,7 @@ namespace USFMToolsSharp.Renderers.Docx
                     else
                     {
                         // Use the default chapter text for this section, e.g. "Chapter 1"
-                        chapterMarker.SetText("Chapter " + simpleNumber);
+                        chapterMarker.SetText(chapterLabel + " " + simpleNumber);
                     }
                     chapterMarker.FontSize = 20;
 
@@ -294,7 +304,9 @@ namespace USFMToolsSharp.Renderers.Docx
                     newLineBreak.AddBreak(BreakType.TEXTWRAPPING);
                     break;
                 case IDMarker _:
-                    firstChapterOfBook = true;
+                    // This is the start of a new book.
+                    beforeFirstChapter = true;
+                    chapterLabel = chapterLabelDefault;
                     break;
                 case XEndMarker _:
                 case FEndMarker _:

--- a/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
+++ b/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
@@ -155,7 +155,7 @@ namespace USFMToolsSharp.Renderers.Docx
                     break;
                 case QMarker qMarker:
                     XWPFParagraph poetryParagraph = newDoc.CreateParagraph(markerStyle);
-                    poetryParagraph.IndentationLeft = qMarker.Depth;
+                    poetryParagraph.IndentationLeft = qMarker.Depth * 500;
 
                     foreach (Marker marker in input.Contents)
                     {

--- a/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
+++ b/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
@@ -96,7 +96,17 @@ namespace USFMToolsSharp.Renderers.Docx
 
                     XWPFParagraph newChapter = newDoc.CreateParagraph(markerStyle);
                     XWPFRun chapterMarker = newChapter.CreateRun(markerStyle);
-                    chapterMarker.SetText(cMarker.Number.ToString());
+                    string simpleNumber = cMarker.Number.ToString();
+                    if (cMarker.CustomChapterLabel != simpleNumber)
+                    {
+                        // Use the custom label for this section, e.g. "Psalm One" instead of "Chapter 1"
+                        chapterMarker.SetText(cMarker.CustomChapterLabel);
+                    }
+                    else
+                    {
+                        // Use the default chapter text for this section, e.g. "Chapter 1"
+                        chapterMarker.SetText("Chapter " + simpleNumber);
+                    }
                     chapterMarker.FontSize = 20;
 
                     XWPFParagraph chapterVerses = newDoc.CreateParagraph(markerStyle);

--- a/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
+++ b/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
@@ -76,6 +76,7 @@ namespace USFMToolsSharp.Renderers.Docx
 
                     newParagraph.Alignment = configDocx.textAlign;
                     newParagraph.SpacingBetween = configDocx.lineSpacing;
+                    newParagraph.SpacingAfterLines = 50;
 
                     foreach (Marker marker in input.Contents)
                     {
@@ -137,19 +138,19 @@ namespace USFMToolsSharp.Renderers.Docx
                         XWPFRun newLine = parentParagraph.CreateRun();
                         newLine.AddBreak(BreakType.TEXTWRAPPING);
                     }
-                    else 
-                    { 
-                        //AppendSpace(parentParagraph);
-                    }
 
                     XWPFRun verseMarker = parentParagraph.CreateRun(markerStyle);
                     verseMarker.SetText(vMarker.VerseCharacter);
                     verseMarker.Subscript = VerticalAlign.SUPERSCRIPT;
+                    AppendSpace(parentParagraph);
 
                     foreach (Marker marker in input.Contents)
                     {
-                        AppendSpace(parentParagraph);
                         RenderMarker(marker, markerStyle, parentParagraph);
+                    }
+                    if (parentParagraph.Text.EndsWith(" ") == false)
+                    {
+                        AppendSpace(parentParagraph);
                     }
                     break;
                 case QMarker qMarker:

--- a/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
+++ b/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
@@ -21,6 +21,8 @@ namespace USFMToolsSharp.Renderers.Docx
         private string chapterLabel = chapterLabelDefault;
         private bool beforeFirstChapter = true;
         private int nextFootnoteNum = 1;
+        private Marker thisMarker = null;
+        private Marker previousMarker = null;
 
         public DocxRenderer()
         {
@@ -68,19 +70,30 @@ namespace USFMToolsSharp.Renderers.Docx
         }
         private void RenderMarker(Marker input, StyleConfig styles, XWPFParagraph parentParagraph = null)
         {
+            // Keep track of the previous marker
+            previousMarker = thisMarker;
+            thisMarker = input;
+
             StyleConfig markerStyle = (StyleConfig)styles.Clone();
             switch (input)
             {
                 case PMarker _:
-                    XWPFParagraph newParagraph = newDoc.CreateParagraph(markerStyle);
 
-                    newParagraph.Alignment = configDocx.textAlign;
-                    newParagraph.SpacingBetween = configDocx.lineSpacing;
-                    newParagraph.SpacingAfterLines = 50;
+                    XWPFParagraph paragraph = parentParagraph;
+                    // If the previous marker was a chapter marker, don't create a new paragraph.
+                    if (!(previousMarker is CMarker _))
+                    {
+                        XWPFParagraph newParagraph = newDoc.CreateParagraph(markerStyle);
+
+                        newParagraph.Alignment = configDocx.textAlign;
+                        newParagraph.SpacingBetween = configDocx.lineSpacing;
+                        newParagraph.SpacingAfterLines = 50;
+                        paragraph = newParagraph;
+                    }
 
                     foreach (Marker marker in input.Contents)
                     {
-                        RenderMarker(marker, markerStyle, newParagraph);
+                        RenderMarker(marker, markerStyle, paragraph);
                     }
                     break;
                 case CLMarker clMarker:

--- a/USFMToolsSharp.Renderers.Docx/USFMToolsSharp.Renderers.Docx.csproj
+++ b/USFMToolsSharp.Renderers.Docx/USFMToolsSharp.Renderers.Docx.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RepositoryUrl>https://github.com/WycliffeAssociates/USFMToolsSharp.Renderers.Docx</RepositoryUrl>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <Authors>@rbnswartz; @BryanHo10</Authors>
+    <Authors>@rbnswartz; @BryanHo10; @PurpleGuitar</Authors>
     <Company>Wycliffe Associates</Company>
     <PackageProjectUrl>https://github.com/WycliffeAssociates/USFMToolsSharp.Renderers.Docx</PackageProjectUrl>
     <RepositoryType />
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
     <PackageReference Include="USFMToolsSharp" Version="1.4.0" />
+    <PackageReference Include="WycliffeAssociates.NPOI.OOXML" Version="2.4.5" />
   </ItemGroup>
 
   <ItemGroup>
@@ -24,12 +25,6 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\npoi\ooxml\NPOI.OOXML.Core.csproj" />
-    <ProjectReference Include="..\..\npoi\openxml4Net\NPOI.OpenXml4Net.Core.csproj" />
-    <ProjectReference Include="..\..\npoi\OpenXmlFormats\NPOI.OpenXmlFormats.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/USFMToolsSharp.Renderers.Docx/USFMToolsSharp.Renderers.Docx.csproj
+++ b/USFMToolsSharp.Renderers.Docx/USFMToolsSharp.Renderers.Docx.csproj
@@ -17,7 +17,6 @@
   <ItemGroup>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
     <PackageReference Include="USFMToolsSharp" Version="1.4.0" />
-    <PackageReference Include="WycliffeAssociates.NPOI" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -25,6 +24,11 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\npoi\ooxml\NPOI.OOXML.csproj" />
+    <ProjectReference Include="..\..\npoi\OpenXmlFormats\NPOI.OpenXmlFormats.csproj" />
   </ItemGroup>
 
 </Project>

--- a/USFMToolsSharp.Renderers.Docx/USFMToolsSharp.Renderers.Docx.csproj
+++ b/USFMToolsSharp.Renderers.Docx/USFMToolsSharp.Renderers.Docx.csproj
@@ -27,8 +27,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\npoi\ooxml\NPOI.OOXML.csproj" />
-    <ProjectReference Include="..\..\npoi\OpenXmlFormats\NPOI.OpenXmlFormats.csproj" />
+    <ProjectReference Include="..\..\npoi\ooxml\NPOI.OOXML.Core.csproj" />
+    <ProjectReference Include="..\..\npoi\openxml4Net\NPOI.OpenXml4Net.Core.csproj" />
+    <ProjectReference Include="..\..\npoi\OpenXmlFormats\NPOI.OpenXmlFormats.Core.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR contains the following changes:
- Footnotes are now rendered as DOCX entities at the bottom of the page.
- Add localized word "Chapter" to chapter headers.
- Create more room between paragraphs in a chapter.
- Remove extra page at end of doc when chapter breaks are turned on.
- Add missing space between end of verse and beginning of next verse.
