### PR TITLE
Fix bug with column count

### DIFF
--- a/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
+++ b/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
@@ -64,6 +64,7 @@ namespace USFMToolsSharp.Renderers.Docx
             finalSection.type = new CT_SectType();
             finalSection.type.val = ST_SectionMark.continuous;
             newDoc.Document.body.sectPr = finalSection;
+            finalSection.cols.num = configDocx.columnCount.ToString();
 
             return newDoc;
 

--- a/USFMToolsSharp.Renderers.Docx/USFMToolsSharp.Renderers.Docx.csproj
+++ b/USFMToolsSharp.Renderers.Docx/USFMToolsSharp.Renderers.Docx.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.4.0</Version>
+    <Version>0.5.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RepositoryUrl>https://github.com/WycliffeAssociates/USFMToolsSharp.Renderers.Docx</RepositoryUrl>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/USFMToolsSharp.Renderers.Docx/USFMToolsSharp.Renderers.Docx.csproj
+++ b/USFMToolsSharp.Renderers.Docx/USFMToolsSharp.Renderers.Docx.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.5.0</Version>
+    <Version>0.5.1</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RepositoryUrl>https://github.com/WycliffeAssociates/USFMToolsSharp.Renderers.Docx</RepositoryUrl>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>


### PR DESCRIPTION
This fixes a bug where the column count would not get set if there were no `\h` section in the document.  This change sets the column count on the final section of the document.