### PR TITLE
Don't crash on missing chapter

### DIFF
--- a/USFMToolsSharp.Renderers.Docx.Tests/DocxRendererTests.cs
+++ b/USFMToolsSharp.Renderers.Docx.Tests/DocxRendererTests.cs
@@ -118,6 +118,14 @@ namespace USFMToolsSharp.Renderers.Docx.Tests
         }
 
         [TestMethod]
+        public void TestNoChapter()
+        {
+            // No chapter or verse 1 -- should render what it can, not crash
+            XWPFDocument doc = renderDoc("Pre text \\v 2 Second verse.");
+            Assert.AreEqual("2 Second verse. ", doc.Paragraphs[0].ParagraphText);
+        }
+
+        [TestMethod]
         public void TestVerseRender()
         {
             Assert.AreEqual("1 This is a simple verse. ", renderDoc("\\c 1 \\v 1 This is a simple verse.").Paragraphs[1].ParagraphText);

--- a/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
+++ b/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
@@ -150,6 +150,16 @@ namespace USFMToolsSharp.Renderers.Docx
                     break;
                 case VMarker vMarker:
 
+                    // If there is no parent paragraph, then we're maybe
+                    // missing a chapter marker prior to this verse.  Let's
+                    // create a stub parent paragraph so we can keep rendering.
+                    if (parentParagraph == null)
+                    {
+                        parentParagraph = newDoc.CreateParagraph(markerStyle);
+                        parentParagraph.SpacingBetween = configDocx.lineSpacing;
+                        parentParagraph.SpacingAfter = 200;
+                    }
+
                     if (configDocx.separateVerses)
                     {
                         XWPFRun newLine = parentParagraph.CreateRun();


### PR DESCRIPTION
This change fixes an issue where the renderer would crash if it encountered a verse outside the context of a chapter.