### PR TITLE
Paragraph Indent Config

### DIFF
--- a/USFMToolsSharp.Renderers.Docx/DocxConfig.cs
+++ b/USFMToolsSharp.Renderers.Docx/DocxConfig.cs
@@ -23,6 +23,8 @@ namespace USFMToolsSharp.Renderers.Docx
         {
             textAlign = ParagraphAlignment.LEFT;
             rightToLeft = false;
+            marginLeft = 0;
+            marginRight = 0;
             columnCount = 1;
             lineSpacing = 1;
             showPageNumbers = true;
@@ -30,16 +32,12 @@ namespace USFMToolsSharp.Renderers.Docx
         }
         public DocxConfig(
             int fontSize = 12,
-            int marginLeft = 0,
-            int marginRight = 0,
             bool separateChapters = false, 
             bool separateVerses = false, 
             bool showPageNumbers = true
         ) : this()
         {
             this.fontSize = fontSize;
-            this.marginLeft = marginLeft;
-            this.marginRight = marginRight;
             this.separateChapters = separateChapters;
             this.separateVerses = separateVerses;
             this.showPageNumbers = showPageNumbers;

--- a/USFMToolsSharp.Renderers.Docx/DocxConfig.cs
+++ b/USFMToolsSharp.Renderers.Docx/DocxConfig.cs
@@ -7,6 +7,8 @@ namespace USFMToolsSharp.Renderers.Docx
 
         public ParagraphAlignment textAlign;
         public bool rightToLeft;
+        public int marginLeft; // cm unit
+        public int marginRight; // cm unit
         public string rightToLeftLangCode;
         public int columnCount;
         public double lineSpacing;
@@ -26,9 +28,18 @@ namespace USFMToolsSharp.Renderers.Docx
             showPageNumbers = true;
             fontSize = 12;
         }
-        public DocxConfig(int fontSize = 12, bool separateChapters = false, bool separateVerses = false, bool showPageNumbers = true) : this()
+        public DocxConfig(
+            int fontSize = 12,
+            int marginLeft = 0,
+            int marginRight = 0,
+            bool separateChapters = false, 
+            bool separateVerses = false, 
+            bool showPageNumbers = true
+        ) : this()
         {
             this.fontSize = fontSize;
+            this.marginLeft = marginLeft;
+            this.marginRight = marginRight;
             this.separateChapters = separateChapters;
             this.separateVerses = separateVerses;
             this.showPageNumbers = showPageNumbers;

--- a/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
+++ b/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
@@ -90,7 +90,7 @@ namespace USFMToolsSharp.Renderers.Docx
                     // If the previous marker was a chapter marker, don't create a new paragraph.
                     if (!(previousMarker is CMarker _))
                     {
-                        XWPFParagraph newParagraph = newDoc.CreateParagraph(markerStyle);
+                        XWPFParagraph newParagraph = newDoc.CreateParagraph(markerStyle, configDocx);
                         newParagraph.SetBidi(configDocx.rightToLeft);
                         newParagraph.Alignment = configDocx.textAlign;
                         newParagraph.SpacingBetween = configDocx.lineSpacing;
@@ -129,7 +129,7 @@ namespace USFMToolsSharp.Renderers.Docx
 
                     createBookHeaders(previousBookHeader);
 
-                    XWPFParagraph newChapter = newDoc.CreateParagraph(markerStyle);
+                    XWPFParagraph newChapter = newDoc.CreateParagraph(markerStyle, configDocx);
                     newChapter.SetBidi(configDocx.rightToLeft);
                     newChapter.Alignment = configDocx.textAlign;
                     newChapter.SpacingBetween = configDocx.lineSpacing;
@@ -151,7 +151,7 @@ namespace USFMToolsSharp.Renderers.Docx
                     chapterMarker.SetText(currentChapterLabel);
                     chapterMarker.FontSize = 20;
 
-                    XWPFParagraph chapterVerses = newDoc.CreateParagraph(markerStyle);
+                    XWPFParagraph chapterVerses = newDoc.CreateParagraph(markerStyle, configDocx);
                     chapterVerses.SetBidi(configDocx.rightToLeft);
                     chapterVerses.Alignment = configDocx.textAlign;
                     chapterVerses.SpacingBetween = configDocx.lineSpacing;
@@ -170,7 +170,7 @@ namespace USFMToolsSharp.Renderers.Docx
                     // create a stub parent paragraph so we can keep rendering.
                     if (parentParagraph == null)
                     {
-                        parentParagraph = newDoc.CreateParagraph(markerStyle);
+                        parentParagraph = newDoc.CreateParagraph(markerStyle, configDocx);
                         parentParagraph.SetBidi(configDocx.rightToLeft);
                         parentParagraph.Alignment = configDocx.textAlign;
                         parentParagraph.SpacingBetween = configDocx.lineSpacing;
@@ -199,11 +199,11 @@ namespace USFMToolsSharp.Renderers.Docx
                     }
                     break;
                 case QMarker qMarker:
-                    XWPFParagraph poetryParagraph = newDoc.CreateParagraph(markerStyle);
+                    XWPFParagraph poetryParagraph = newDoc.CreateParagraph(markerStyle, configDocx);
                     poetryParagraph.SetBidi(configDocx.rightToLeft);
                     poetryParagraph.Alignment = configDocx.textAlign;
                     poetryParagraph.SpacingBetween = configDocx.lineSpacing;
-                    poetryParagraph.IndentationLeft = qMarker.Depth * 500;
+                    poetryParagraph.IndentationLeft += qMarker.Depth * 500;
                     poetryParagraph.SpacingAfter = 200;
 
                     foreach (Marker marker in input.Contents)
@@ -243,7 +243,7 @@ namespace USFMToolsSharp.Renderers.Docx
 
                     // Write body header text
                     markerStyle.fontSize = 24;
-                    XWPFParagraph newHeader = newDoc.CreateParagraph(markerStyle);
+                    XWPFParagraph newHeader = newDoc.CreateParagraph(markerStyle, configDocx);
                     newHeader.SetBidi(configDocx.rightToLeft);
                     newHeader.SpacingAfter = 200;
                     XWPFRun headerTitle = newHeader.CreateRun(markerStyle);
@@ -390,7 +390,7 @@ namespace USFMToolsSharp.Renderers.Docx
                     // If the previous marker was a chapter marker, don't create a new paragraph.
                     if (!(previousMarker is CMarker _))
                     {
-                        XWPFParagraph newParagraph = newDoc.CreateParagraph(markerStyle);
+                        XWPFParagraph newParagraph = newDoc.CreateParagraph(markerStyle, configDocx);
                         newParagraph.SetBidi(configDocx.rightToLeft);
                         newParagraph.Alignment = configDocx.textAlign;
                         newParagraph.SpacingBetween = configDocx.lineSpacing;

--- a/USFMToolsSharp.Renderers.Docx/Extensions/UnitValue.cs
+++ b/USFMToolsSharp.Renderers.Docx/Extensions/UnitValue.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace USFMToolsSharp.Renderers.Docx.Extensions
+{
+    public static class UnitValue
+    {
+        public const int TWIP_PER_CM = 567;
+    }
+}

--- a/USFMToolsSharp.Renderers.Docx/Extensions/XWPFDocumentExtensions.cs
+++ b/USFMToolsSharp.Renderers.Docx/Extensions/XWPFDocumentExtensions.cs
@@ -14,5 +14,13 @@ namespace USFMToolsSharp.Renderers.Docx.Extensions
             para.Alignment = (styles.isAlignRight ? ParagraphAlignment.RIGHT : ParagraphAlignment.LEFT);
             return para;
         }
+
+        public static XWPFParagraph CreateParagraph(this XWPFDocument doc, StyleConfig styles, DocxConfig config)
+        {
+            XWPFParagraph para = doc.CreateParagraph(styles);
+            para.IndentationLeft = config.marginLeft * UnitValue.TWIP_PER_CM;
+            para.IndentationRight = config.marginRight * UnitValue.TWIP_PER_CM;
+            return para;
+        }
     }
 }


### PR DESCRIPTION
This PR adds the config properties for left and right indentation/margin of the document body. 
It applies to all paragraph created using the `XWPFDocument.CreateParagraph()` extension

 - USFM Converter dependency, resolving the [Add space for notetaking](https://github.com/WycliffeAssociates/quick_usfm_converter/issues/61)