### PR TITLE
Fix null reference when no bookname

### DIFF
--- a/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
+++ b/USFMToolsSharp.Renderers.Docx/DocxRenderer.cs
@@ -523,7 +523,7 @@ namespace USFMToolsSharp.Renderers.Docx
             }
 
             // Book name
-            run.AddNewT().Value = bookname;
+            run.AddNewT().Value = bookname == null ? "" : bookname;
             // Chapter name
             if (currentChapterLabel.Length > 0)
             {


### PR DESCRIPTION
Fix rendering crash by ensuring we don't put a null reference into the document tree.